### PR TITLE
Updated definition of key:value usage

### DIFF
--- a/tagging_resources.md
+++ b/tagging_resources.md
@@ -23,7 +23,7 @@ To see a full list of tags in your account, go to **Manage > Account**, and sele
 ## Tagging rules and limitations
 {: #limits}
 
-The maximum size of a tag is 128 characters. The permitted characters are A-Z, 0-9, white space, underscore, hyphen, period, and colon, and tags  are case-insensitive. Colons turn the tag into a `key:value` pair. You can't use a colon in a tag without creating a `key:value` pair. A comma separates tags, so commas can't be used within the tag name itself.
+The maximum size of a tag is 128 characters. Tags are case-insensitive and the permitted characters are A-Z, 0-9, white space, underscore, hyphen, period, and a single colon. Colons are treated uniquely to work *like* a `key:value` pair but the key will always remain as "name" in the underlying object. The `value` will be the provided string with the colon. A comma separates tags, so commas can't be used within the tag name itself.
 
 
 ## Adding and removing tags on a resource


### PR DESCRIPTION
Clarify that the object model does not treat tags with colons as key:value. The underlying key remains "name".